### PR TITLE
Add swapon command before nixos-generate-config command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -117,6 +117,7 @@ installer:
 # mount /dev/sda4 /mnt
 # mkdir /mnt/boot
 # mount /dev/sda1 /mnt/boot
+# swapon /dev/disk/by-label/nixosswap
 ----
 
 *Make sure you mount `/dev/sda1` under `/mnt/boot`.*


### PR DESCRIPTION
Fixes #7 'Mention swapon for the prepared swap disk' by @vrthra.
